### PR TITLE
Terminus::Proxy::External broken

### DIFF
--- a/lib/terminus/proxy/external.rb
+++ b/lib/terminus/proxy/external.rb
@@ -2,6 +2,8 @@ module Terminus
   class Proxy
     
     class External < Rack::Proxy
+      attr_reader :uri
+
       def initialize(uri)
         @uri = uri
       end


### PR DESCRIPTION
The external proxy was missing a uri reader that other code was relying upon. Looks like a typo.
